### PR TITLE
add -link_mpi=dbg to debug flags

### DIFF
--- a/configuration/scripts/machines/Macros.cheyenne_intel
+++ b/configuration/scripts/machines/Macros.cheyenne_intel
@@ -12,7 +12,7 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.hera_intel
+++ b/configuration/scripts/machines/Macros.hera_intel
@@ -12,7 +12,7 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
 else
   FFLAGS     += -O2
 endif

--- a/configuration/scripts/machines/Macros.orion_intel
+++ b/configuration/scripts/machines/Macros.orion_intel
@@ -12,7 +12,7 @@ FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -trace
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)
-  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created
+  FFLAGS     += -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -link_mpi=dbg
 else
   FFLAGS     += -O2
 endif


### PR DESCRIPTION
Resolves Issue #7 

- add link_mpi=dbg when compiling on hera, orion and cheyenne.intel in debug mode