### PR TITLE
remove compiler warnings for CICE; fix missing j-loop index

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
@@ -1763,9 +1763,11 @@ contains
                 end do
              end do
           else
-             do i = ilo, ihi
-                n = n+1
-                dataPtr1d(n) = input(i,j,index,iblk)
+             do j = jlo, jhi
+                do i = ilo, ihi
+                   n = n+1
+                   dataPtr1d(n) = input(i,j,index,iblk)
+                end do
              end do
           end if
        end do

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -7,7 +7,8 @@ module ice_prescribed_mod
   ! Ice/ocean fluxes are set to zero, and ice dynamics are not calculated.
   ! Regridding and data cycling capabilities are included.
 
-  use ESMF
+  use ESMF, only : ESMF_Clock, ESMF_Mesh, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_Finalize, ESMF_END_ABORT
 
 #ifndef CESMCOUPLED
 
@@ -23,6 +24,7 @@ contains
     type(ESMF_Mesh)        , intent(in)  :: mesh
     integer                , intent(out) :: rc
     ! do nothing
+    rc = ESMF_SUCCESS
   end subroutine ice_prescribed_init
 
 #else


### PR DESCRIPTION
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1984 for CICE component in UFS
- fixes missing j-loop in for 4-d export variables. The export of 4-d variables is unused in UFS. If it were used in other systems, it would only be for case where ungridded dimensions were not being used and when not masking by the land mask or ifraction.