### PR TITLE
Do not use OMP in one do loop if Intel LLVM is used

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -2325,9 +2325,11 @@
       ! increment field
       !---------------------------------------------------------------
 
+#ifndef __INTEL_LLVM_COMPILER
       !$OMP PARALLEL DO PRIVATE(iblk,i,j,ilo,ihi,jlo,jhi,this_block, &
       !$OMP             k,n,qn,ns,sn,rho_ocn,rho_ice,Tice,Sbr,phi,rhob,dfresh,dfsalt,sicen, &
       !$OMP             worka,workb,worka3,Tinz4d,Sinz4d,Tsnz4d)
+#endif
 
       do iblk = 1, nblocks
          this_block = get_block(blocks_ice(iblk),iblk)
@@ -3637,7 +3639,9 @@
          call accum_hist_snow (iblk)
 
       enddo                     ! iblk
+#ifndef __INTEL_LLVM_COMPILER
       !$OMP END PARALLEL DO
+#endif
 
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Conditionally enable OMP directives in ice_history.F90 if compiler is not IntelLLVM, which has issues with this loop.
- [ ] Developer(s): 
    ENTER INFORMATION HERE
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [ ] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
