### PR TITLE
Insert a sea ice concentration field (possibly generated from data assimilation)

### DIFF
--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1171,7 +1171,7 @@
       call broadcast_scalar(restore_ocn,          master_task)
       call broadcast_scalar(trestore,             master_task)
       call broadcast_scalar(restore_ice,          master_task)
-      call broadcast_scalar(insert_ice,           master_task)
+      call broadcast_scalar(insert_sic,           master_task)
       call broadcast_scalar(debug_forcing,        master_task)
       call broadcast_array (latpnt(1:2),          master_task)
       call broadcast_array (lonpnt(1:2),          master_task)

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -84,7 +84,7 @@
           restart, restart_ext, restart_coszen, use_restart_time, &
           runtype, restart_file, restart_dir, runid, pointer_file, &
           restart_format, restart_rearranger, restart_iotasks, restart_root, &
-          restart_stride, restart_deflate, restart_chunksize
+          restart_stride, restart_deflate, restart_chunksize, insert_sic
       use ice_history_shared, only: &
           history_precision, hist_avg, history_format, history_file, incond_file, &
           history_dir, incond_dir, version_name, history_rearranger, &
@@ -294,7 +294,7 @@
         atm_data_dir,   ocn_data_dir,    bgc_data_dir,                  &
         atm_data_format, ocn_data_format, rotate_wind,                  &
         oceanmixed_file, atm_data_version,semi_implicit_Tsfc,           &
-        vapor_flux_correction
+        vapor_flux_correction, insert_sic
 
       !-----------------------------------------------------------------
       ! default values
@@ -573,6 +573,7 @@
       restore_ocn     = .false.   ! restore sst if true
       trestore        = 90        ! restoring timescale, days (0 instantaneous)
       restore_ice     = .false.   ! restore ice state on grid edges if true
+      insert_sic      = .false.   ! if true, on restart update concentration from a file
       debug_forcing   = .false.   ! true writes diagnostics for input forcing
 
       latpnt(1) =  90._dbl_kind   ! latitude of diagnostic point 1 (deg)
@@ -1170,6 +1171,7 @@
       call broadcast_scalar(restore_ocn,          master_task)
       call broadcast_scalar(trestore,             master_task)
       call broadcast_scalar(restore_ice,          master_task)
+      call broadcast_scalar(insert_ice,           master_task)
       call broadcast_scalar(debug_forcing,        master_task)
       call broadcast_array (latpnt(1:2),          master_task)
       call broadcast_array (lonpnt(1:2),          master_task)
@@ -2683,6 +2685,7 @@
          write(nu_diag,1011) ' restore_ice      = ', restore_ice
          if (restore_ice .or. restore_ocn) &
          write(nu_diag,1021) ' trestore         = ', trestore
+         write(nu_diag,1011) ' insert_sic       = ', insert_sic
 
          write(nu_diag,*) ' '
          write(nu_diag,'(a31,2f8.2)') 'Diagnostic point 1: lat, lon =', &

--- a/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
@@ -760,7 +760,7 @@
                        fiso_ocn  =  fiso_ocn(i,j,:,iblk),      &
                        flux_bio  =  flux_bio(i,j,:,iblk),      &
                        Tf        =        Tf(i,j,  iblk),      &
-                       limit_aice_in = .true. )
+                       limit_aice = .true. )
 
                   call icepack_aggregate( &
                                    aicen = aicen(i,j,:,iblk),     &

--- a/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
+++ b/cicecore/cicedyn/infrastructure/ice_restart_driver.F90
@@ -25,7 +25,7 @@
           field_loc_Eface, field_loc_Nface, &
           field_type_scalar, field_type_vector
       use ice_restart_shared, only: restart_dir, pointer_file, &
-          runid, use_restart_time, lenstr, restart_coszen
+          runid, use_restart_time, lenstr, restart_coszen, insert_sic
       use ice_restart
       use ice_exit, only: abort_ice
       use ice_fileunits, only: nu_diag, nu_rst_pointer, nu_restart, nu_dump
@@ -33,6 +33,8 @@
       use icepack_intfc, only: icepack_warnings_flush, icepack_warnings_aborted
       use icepack_intfc, only: icepack_aggregate
       use icepack_intfc, only: icepack_query_tracer_indices, icepack_query_tracer_sizes
+      use icepack_intfc, only: icepack_query_parameters
+      use icepack_intfc, only: icepack_query_tracer_flags
 
       implicit none
       private
@@ -297,6 +299,11 @@
           aice0, aicen, vicen, vsnon, trcrn, aice_init, uvel, vvel, &
           uvelE, vvelE, uvelN, vvelN, &
           trcr_base, nt_strata, n_trcr_strata
+      use icepack_itd, only: cleanup_itd  !for insert_sic
+      use ice_arrays_column, only: first_ice, hin_max
+      use ice_flux, only: fpond, fresh, fsalt, fhocn
+      use ice_flux_bgc, only: faero_ocn, fiso_ocn, flux_bio
+      use ice_calendar, only: dt
 
       character (*), optional :: ice_ic
 
@@ -308,7 +315,8 @@
          nt_Tsfc, nt_sice, nt_qice, nt_qsno
 
       logical (kind=log_kind) :: &
-         diag
+         diag, &
+         tr_aero, tr_pond_topo
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
          work1
@@ -324,6 +332,7 @@
 
       call icepack_query_tracer_indices(nt_Tsfc_out=nt_Tsfc, nt_sice_out=nt_sice, &
            nt_qice_out=nt_qice, nt_qsno_out=nt_qsno)
+      call icepack_query_tracer_flags(tr_aero_out=tr_aero, tr_pond_topo_out=tr_pond_topo)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
@@ -717,6 +726,67 @@
          npt = npt - istep0
       endif
 
+      !-----------------------------------------------------------------
+      ! update concentration from a file
+      !-----------------------------------------------------------------
+      if (insert_sic) then
+
+         if (my_task == master_task) &
+              write(nu_diag,*) "Inserting sic"
+
+         call direct_insert_sic
+
+         !-----------------------------------------------------------------
+         ! Ensure ice is binned in correct categories
+         !-----------------------------------------------------------------
+         do iblk = 1, nblocks
+            do j = 1, ny_block
+            do i = 1, nx_block
+               if (tmask(i,j,iblk)) then
+
+                  call cleanup_itd(dt,    hin_max,             &
+                       aicen(i,j,:,iblk), trcrn(i,j,:,:,iblk), &
+                       vicen(i,j,:,iblk), vsnon(i,j,:,  iblk), &
+                       aice0(i,j,  iblk),  aice(i,j,    iblk), &
+                       tr_aero,           tr_pond_topo,        &
+                       first_ice(i,j,:,iblk),                  &
+                       trcr_depend,       trcr_base,           &
+                       n_trcr_strata,     nt_strata,           &
+                       fpond     =     fpond(i,j,  iblk),      &
+                       fresh     =     fresh(i,j,  iblk),      &
+                       fsalt     =     fsalt(i,j,  iblk),      &
+                       fhocn     =     fhocn(i,j,  iblk),      &
+                       faero_ocn = faero_ocn(i,j,:,iblk),      &
+                       fiso_ocn  =  fiso_ocn(i,j,:,iblk),      &
+                       flux_bio  =  flux_bio(i,j,:,iblk),      &
+                       Tf        =        Tf(i,j,  iblk),      &
+                       limit_aice_in = .true. )
+
+                  call icepack_aggregate( &
+                                   aicen = aicen(i,j,:,iblk),     &
+                                   trcrn = trcrn(i,j,:,:,iblk),   &
+                                   vicen = vicen(i,j,:,iblk),     &
+                                   vsnon = vsnon(i,j,:,iblk),     &
+                                   aice  = aice (i,j,  iblk),     &
+                                   trcr  = trcr (i,j,:,iblk),     &
+                                   vice  = vice (i,j,  iblk),     &
+                                   vsno  = vsno (i,j,  iblk),     &
+                                   aice0 = aice0(i,j,  iblk),     &
+                                   trcr_depend   = trcr_depend,   &
+                                   trcr_base     = trcr_base,     &
+                                   n_trcr_strata = n_trcr_strata, &
+                                   nt_strata     = nt_strata,     &
+                                   Tf            = Tf(i,j,iblk))
+
+                  aice_init(i,j,iblk) = aice(i,j,iblk)
+
+               endif  ! tmask
+            enddo     ! i
+            enddo     ! j
+         enddo        ! iblk
+
+      endif !insert_sic
+
       end subroutine restartfile
 
 !=======================================================================
@@ -1090,6 +1160,311 @@
       endif
 
       end subroutine restartfile_v4
+
+!=======================================================================
+
+!=======================================================================
+!  Direct insertion of ice concentration read from file.
+!
+!  Posey, et. al. 2015: Improving Arctic sea ice edge forecasts by
+!  assimilating high horizontal resolution sea ice concentration
+!  data into the US Navy's ice forecast systems.
+!  The Cryosphere.  doi:10.5194/tc-9-1735-2015
+!
+!  Alan J. Wallcraft, COAPS/FSU, Nov 2024
+
+      subroutine direct_insert_sic
+
+        use ice_blocks, only: nghost, nx_block, ny_block
+        use ice_domain, only: nblocks
+        use ice_domain_size, only: nilyr, nslyr, ncat, max_blocks
+        use ice_grid, only: tmask
+        use ice_communicate, only: my_task, master_task
+        use ice_constants, only: c0, c1, c4, p5, p2, p1, p01, p001, &
+             field_loc_center, field_loc_NEcorner, &
+             field_type_scalar, field_type_vector
+        use ice_fileunits, only: nu_diag
+        use ice_flux, only:  &
+             Tair, Tf, salinz, Tmltz, sst,                  &
+             stressp_1, stressp_2, stressp_3, stressp_4,    &
+             stressm_1, stressm_2, stressm_3, stressm_4,    &
+             stress12_1, stress12_2, stress12_3, stress12_4
+        use ice_state, only:  &
+             aice, aicen, vicen, vsnon, trcrn
+        use ice_read_write, only: ice_check_nc, ice_read_nc
+        use ice_arrays_column, only: hin_max
+        ! use icepack_mushy_physics, only: enthalpy_mush
+        use icepack_intfc, only: icepack_init_trcr
+#ifdef USE_NETCDF
+        use netcdf
+#endif
+
+        ! --- local variables
+        real(kind=dbl_kind) :: &
+             q     ,    & ! scale factor
+             aice_m,    & ! model aice
+             aice_o,    & ! observation aice
+             aice_t,    & ! target aice
+             aice_i,    & ! insert ice
+             slope,     & ! used to compute surf Temp
+             Ti,        & ! target surface temperature
+             edge_om,   & ! nominal ice edge zone
+             diff_om,   & ! allowed model vs obs difference
+             hin_om,    & ! new ice thickness
+             aicen_old, & ! old value of aice to check when adding ice
+             vsnon_old, & ! old value of snow volume to check when adding ice
+             Tsfc         ! surface temp.
+        integer (kind=int_kind) :: ncid, status
+        integer (kind=int_kind) :: &
+             i, j, k, n, iblk  ! counting  indices
+        logical (kind=log_kind) :: &
+             diag  ! diagnostic output
+        real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
+             work1
+        real (kind=dbl_kind), dimension(nilyr) :: &
+             qin             ! ice enthalpy (J/m3)
+        real (kind=dbl_kind), dimension(nslyr) :: &
+             qsn             ! snow enthalpy (J/m3)
+
+        ! parameters from icepack
+        real (kind=dbl_kind) :: &
+             puny, Tffresh, Tsmelt, Lfresh, cp_ice, cp_ocn, &
+             rhos, rhoi
+        integer (kind=int_kind) :: &
+             nt_Tsfc, nt_sice, nt_qice, nt_qsno, &
+             ktherm
+        character(len=*), parameter :: subname = '(direct_insert_sic)'
+
+        diag = .true.
+
+        ! get parameters from icepack
+        call icepack_query_parameters( &
+             puny_out=puny,            &
+             Tffresh_out=Tffresh,      &
+             Tsmelt_out=Tsmelt,        &
+             Lfresh_out=Lfresh,        &
+             cp_ice_out=cp_ice,        &
+             cp_ocn_out=cp_ocn,        &
+             rhos_out=rhos,            &
+             rhoi_out=rhoi,            &
+             ktherm_out=ktherm         )
+
+        call icepack_query_tracer_indices( &
+             nt_Tsfc_out=nt_Tsfc,          &
+             nt_sice_out=nt_sice,          &
+             nt_qice_out=nt_qice,          &
+             nt_qsno_out=nt_qsno           )
+
+        call icepack_warnings_flush(nu_diag)
+        if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
+             file=__FILE__, line=__LINE__)
+
+#ifdef USE_NETCDF
+        if (my_task == master_task) then
+           write(nu_diag,*) "direct_insert_sic"
+           status = nf90_open(trim(restart_dir)//'/sic.nc', nf90_nowrite, ncid)
+           call ice_check_nc(status, subname//' ERROR: open '//trim(restart_dir)//'/sic.nc', file=__FILE__, line=__LINE__)
+        endif !master_task
+        call ice_read_nc(ncid,1,'sic',work1, diag, &
+                         field_loc=field_loc_center, &
+                         field_type=field_type_scalar)
+        if (my_task == master_task) then
+           ! ncid is only valid on master
+           status = nf90_close(ncid)
+           call ice_check_nc(status, subname//' ERROR: closing', file=__FILE__, line=__LINE__)
+        endif
+#else
+        call abort_ice(subname//' ERROR: USE_NETCDF cpp not defined', &
+            file=__FILE__, line=__LINE__)
+#endif
+
+        edge_om = p2  ! nominal ice edge zone
+        diff_om = p1  ! allowed model vs obs difference
+        hin_om  = hin_max(1)*0.9_dbl_kind  !new ice thickness
+
+        do iblk = 1, nblocks
+           do j = 1, ny_block
+           do i = 1, nx_block
+
+              aice_o = work1(i,j,iblk) ! obs.  ice concentration
+              aice_m = aice(i,j,iblk)  ! model ice concentration
+
+              if     (.not.tmask(i,j,iblk)) then
+                 ! land - do nothing
+              elseif (aice_o.gt.p01 .and. &
+                   abs(aice_o-aice_m).le.p01) then
+                 ! model and obs are very close - do nothing
+              elseif (min(aice_o,aice_m).ge.edge_om .and. &
+                   abs(aice_o-aice_m).le.diff_om) then
+                 ! model and obs are close enough - do nothing
+              elseif (aice_o.eq.aice_m) then
+              elseif (aice_o.lt.aice_m) then
+                 if (aice_o.lt.p01)then
+                    ! --- remove all ice ---
+                    ! warm sst so the ice won't grow immediately
+                    sst(i,j,iblk) = sst(i,j,iblk) + p2
+                    do n=1,ncat
+                       aicen(i,j,n,iblk) = c0
+                       vicen(i,j,n,iblk) = c0
+                       vsnon(i,j,n,iblk) = c0
+                       call icepack_init_trcr( &
+                            Tair     =   Tair(i,j,  iblk), &
+                            Tf       =     Tf(i,j,  iblk), &
+                            Sprofile = salinz(i,j,:,iblk), &
+                            Tprofile =  Tmltz(i,j,:,iblk), &
+                            Tsfc     = Tsfc,               &
+                            qin      = qin(:),             &
+                            qsn      = qsn(:)              )
+                       ! surface temperature
+                       trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                       ! ice enthalpy, salinity
+                       do k = 1, nilyr
+                          trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                          trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                       enddo  ! nilyr
+                       ! snow enthalpy
+                       do k = 1, nslyr
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                       enddo  ! nslyr
+                    enddo !n
+                    stressp_1 (i,j,iblk) = c0
+                    stressp_2 (i,j,iblk) = c0
+                    stressp_3 (i,j,iblk) = c0
+                    stressp_4 (i,j,iblk) = c0
+                    stressm_1 (i,j,iblk) = c0
+                    stressm_2 (i,j,iblk) = c0
+                    stressm_3 (i,j,iblk) = c0
+                    stressm_4 (i,j,iblk) = c0
+                    stress12_1(i,j,iblk) = c0
+                    stress12_2(i,j,iblk) = c0
+                    stress12_3(i,j,iblk) = c0
+                    stress12_4(i,j,iblk) = c0
+                 else !aice_o.ge.p01
+                    if     (aice_o.lt.edge_om) then
+                       ! --- target ice conc. is obs.
+                       aice_t = aice_o
+                    else !aice_m-aice_o.gt.diff_om
+                       ! --- target ice conc. is obs.+diff_om
+                       aice_t = aice_o + diff_om
+                    endif
+                    ! --- reduce ice to the target concentration,
+                    !     completely exhasting ice categories in order ---
+                    aice_i = aice_m - aice_t   !>=0.0
+                    do n=1,ncat
+                       if     (aice_i.le.p001) then
+                          exit
+                       elseif (aice_i.ge.aicen(i,j,n,iblk)) then
+                          ! --- remove all of this category
+                          aice_i = aice_i - aicen(i,j,n,iblk)
+                          aicen(i,j,n,iblk) = c0
+                          vicen(i,j,n,iblk) = c0
+                          vsnon(i,j,n,iblk) = c0
+                          call icepack_init_trcr( &
+                               Tair     =   Tair(i,j,  iblk), &
+                               Tf       =     Tf(i,j,  iblk), &
+                               Sprofile = salinz(i,j,:,iblk), &
+                               Tprofile =  Tmltz(i,j,:,iblk), &
+                               Tsfc     = Tsfc,               &
+                               qin      = qin(:),             &
+                               qsn      = qsn(:)              )
+                          ! surface temperature
+                          trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                          ! ice enthalpy, salinity
+                          do k = 1, nilyr
+                             trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                             trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                          enddo  ! nilyr
+                          ! snow enthalpy
+                          do k = 1, nslyr
+                             trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                          enddo  ! nslyr
+                       else  !aice_i.lt.aicen(i,j,n,iblk)
+                          ! --- remove part of this category
+                          q = (aicen(i,j,n,iblk) - aice_i) &
+                               /aicen(i,j,n,iblk)              !<1
+                          aice_i = c0
+
+                          ! reduce aicen, vicen, vsnon by q
+                          ! do not alter Tsfc since there is already
+                          ! ice here.
+                          aicen(i,j,n,iblk) = q*aicen(i,j,n,iblk)
+                          vicen(i,j,n,iblk) = q*vicen(i,j,n,iblk)
+                          vsnon(i,j,n,iblk) = q*vsnon(i,j,n,iblk)
+                       endif    ! aice_i.gt.p001 and aice_i.lt.aicen
+                    enddo       ! n
+                 endif          ! aice_o.lt.p01
+              elseif (aice_o.gt.p01) then  ! .and. aice_o.gt.aicen
+                 if     (aice_m.lt.edge_om) then
+                    ! --- target ice conc. is obs.
+                    aice_t = aice_o
+                 else !aice_o-aice_m.gt.diff_om
+                    ! --- target ice conc. is obs.-diff_om
+                    aice_t = aice_o - diff_om
+                 endif
+                 q = (aice_t-aice_m)
+                 ! --- add ice to the target concentration,
+                 ! --- with all new ice in category 1
+                 ! --- cool sst so the ice won't melt immediately
+                 sst(  i,j,  iblk) = sst(  i,j,  iblk) - q  ! 0 <= q <= 1
+                 aicen_old         = aicen(i,j,1,iblk)  ! store to check for zero ice later
+                 vsnon_old         = vsnon(i,j,1,iblk)  ! store to check for zero snow later
+                 aicen(i,j,1,iblk) = aicen(i,j,1,iblk) + q
+                 vicen(i,j,1,iblk) = vicen(i,j,1,iblk) + q*hin_om
+                 vsnon(i,j,1,iblk) = vsnon(i,j,1,iblk) + q*hin_om*p2
+
+                 ! ------------------------------------------------------
+                 ! check for zero snow in 1st category.
+                 ! It is possible that there was ice
+                 ! but no snow. This would skip the loop below and an
+                 ! error in snow thermo would occur. If snow was zero
+                 ! specify enthalpy here
+                 ! ------------------------------------------------------
+                 if (vsnon_old < puny) then
+                    do n=1,1           ! only do 1st category
+                       ! --- snow layers
+                       trcrn(i,j,nt_Tsfc,n,iblk) =   &      ! Tsfc
+                            min(Tsmelt,Tair(i,j,iblk) - Tffresh)
+                       Ti = min(c0,trcrn(i,j,nt_Tsfc,n,iblk))
+                       do k=1,nslyr
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = -rhos*(Lfresh - cp_ice*Ti)
+                       enddo ! k
+                    enddo ! n = 1,1
+                 endif
+
+                 ! ------------------------------------------------------
+                 ! check for zero aice in 1st category.
+                 ! if adding to an initially zero ice, we must define
+                 ! qice, qsno, sice so thermo does not blow up.
+                 ! ------------------------------------------------------
+                 if (aicen_old < puny) then
+                    do n =1,1  ! only do 1st category
+                       call icepack_init_trcr( &
+                            Tair     =   Tair(i,j,  iblk), &
+                            Tf       =     Tf(i,j,  iblk), &
+                            Sprofile = salinz(i,j,:,iblk), &
+                            Tprofile =  Tmltz(i,j,:,iblk), &
+                            Tsfc     = Tsfc,               &
+                            qin      = qin(:),             &
+                            qsn      = qsn(:)              )
+                       ! surface temperature
+                       trcrn(i,j,nt_Tsfc,n,iblk) = Tsfc ! deg C
+                       ! ice enthalpy, salinity
+                       do k = 1, nilyr
+                          trcrn(i,j,nt_qice+k-1,n,iblk) = qin(k)
+                          trcrn(i,j,nt_sice+k-1,n,iblk) = salinz(i,j,k,iblk)
+                       enddo
+                       ! snow enthalpy
+                       do k = 1, nslyr
+                          trcrn(i,j,nt_qsno+k-1,n,iblk) = qsn(k)
+                       enddo               ! nslyr
+                    enddo       ! n
+                 endif          ! qice == c0
+              endif             ! aice_o vs aice_m or tmask
+           enddo                ! j
+           enddo                ! i
+        enddo                   ! iblk
+
+      end subroutine direct_insert_sic
 
 !=======================================================================
 

--- a/cicecore/shared/ice_restart_shared.F90
+++ b/cicecore/shared/ice_restart_shared.F90
@@ -14,6 +14,9 @@
          restart_coszen, &   ! if true, read/write coszen
          use_restart_time ! if true, use time written in core restart file
 
+     logical(kind=log_kind), public :: &
+         insert_sic        ! if true, update restart concentation from a file
+
       character (len=char_len), public :: &
          runtype           ! initial, continue, hybrid, branch
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    This feature is being _ported_ from CICE4, that is used in [RTOFS](https://github.com/NOAA-EMC/RTOFS_GLO/):
    - We use the sea ice concentration from data assimilation.
    - In this (CICE6) version usage is turned `ON` (default: `OFF`) via a logical: `insert_sic` variable.
    - See similar/same implementation in the old (CICE4) version of [ice_restart.F90,](https://github.com/NOAA-EMC/RTOFS_GLO/blob/develop/sorc/rtofs_hycom.fd/src_2.2.99DHMTi-dist2B_relo_cice_v4.0e/source/ice_restart.F90) search for `insert_ssmi`.
   - @awallcraft ported the code he wrote (and is used in CICE4) to CICE6.

[@NickSzapiro-NOAA in reply to: `Can you add some text/description in comments` see ⬇️]
One of the main goals of a data assimilation (DA)/prediction system that strives to provide close to _observed_ sea ice concentrations and ice edge is to be able to _reconcile_ the differences in modeled and _observed_ sea ice concentrations derived from space borne instruments. [Posey et al., 2025](https://tc.copernicus.org/articles/9/1735/2015/) implemented such a method with CICE4, it is hereby ported to CICE6. By default this feature is turned `OFF`. To turn it `ON`, set `insert_sic` to `.true.` in `ice_in` (input) namelist file and provide `sic.nc` to be able to nudge the modeled ice concentration to that from data assimilated (or observed) concentration.

- [x] Developer(s): 
    @awallcraft

- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
    - Tested against the `develop` branch of the NOAA-EMC CICE fork: https://github.com/NOAA-EMC/CICE.git
    - Test was [`datm_cdeps_mx025_gefs`.](https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/tests/datm_cdeps_mx025_gefs) At orion/hercules, paths:
      - Baseline (`develop` branch): `/work/noaa/stmp/santa/stmp/santa/FV3_RT/rt_3352132/datm_cdeps_mx025_gefs_intel/BASL/`
      - Control (`sanAkel:alan_ssmi` branch, i.e., this PR) with `insert_sic= .false.` : `/work/noaa/stmp/santa/stmp/santa/FV3_RT/rt_3352132/datm_cdeps_mx025_gefs_intel/CTRL` 
      - Experiment (Same as above Control, but with `insert_sic= .true.`): `/work/noaa/stmp/santa/stmp/santa/FV3_RT/rt_3352132/datm_cdeps_mx025_gefs_intel/EXP`
    
    - Results:
      - Control and Baseline: No change in answers, i.e., bit wise identical `RESTART/iced.2011-10-02-00000.nc`.
      - Experiment and Control: Answers changed in regions as expected. See below for details.

- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit; identical results (when inputs are kept same as now with their default values).
    - [ ] different at roundoff level
    - [ ] more substantial 
   
- Does this PR create or have dependencies on Icepack or any other models?
    - [x] Yes; Icepack.
    - [ ] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No. (No update to Icepack is needed.)
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

## Further details on results:

- All experiments were run for `1`-day.
- Used a stock case [p025 ice-ocean case](https://github.com/ufs-community/ufs-weather-model/blob/4bee7518483e7c0fc2e73c6f5fad7c507962c44c/tests/rt.conf#L292C7-L292C27) of the [UFS Weather Model.](https://github.com/ufs-community/ufs-weather-model/)

| Exp  | `insert_sic` | Remarks | 
| :--  | :--     | --:| 
| BASL | N/A     | Feature not available/implemented; see Fig.1 |
| CTRL | .false. (default value) | No change in answers from BASL |
| EXP  | .true. See test SIC data in Fig.2 | Changes in sea ice concentration that correspond to those in Fig.2, see Fig.3. |

- Fig.1 Sea Ice Concentration (SIC): Initial (left) and Final - Initial (right) after 1-day integration.
- Fig.2 Test SIC data. See both Arctic and Antarctic, where SIC values have been set to 1 and 0.5 respectively.
- Fig.3 Difference in final restart SIC: EXP - CTRL; note the correspondence to regions that were modified in the test SIC data (Fig.2).

## Remarks:
- With this proposed addition, an ability to _insert_ data assimilated sea ice concentration is provided. Implementation is similar/same as in CICE4; see https://github.com/NOAA-EMC/RTOFS_GLO/blob/develop/sorc/rtofs_hycom.fd/src_2.2.99DHMTi-dist2B_relo_cice_v4.0e/source/ice_restart.F90 ; search for `insert_ssmi`. @awallcraft ported the code he wrote (and is used in CICE4) to CICE6.
- There is an [acknowledgement that the coupler and/or MOM6 will need some modifications](https://github.com/NOAA-EMC/CICE/pull/104#issuecomment-3329217803), but that is beyond the scope of _this_ (CICE) repository. Such work will be taken up in future.