### PR TITLE
Add log_restart_fh logging and user option to write logs to CICE output dir

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
@@ -16,7 +16,6 @@
 
       use ice_kinds_mod
       use cice_wrapper_mod, only : t_startf, t_stopf, t_barrierf
-      use cice_wrapper_mod, only : ufs_logfhour
       use ice_fileunits, only: nu_diag
       use ice_arrays_column, only: oceanmixed_ice
       use ice_constants, only: c0, c1
@@ -111,8 +110,8 @@
       use ice_constants, only: c3600
       use ice_boundary, only: ice_HaloUpdate
       use ice_calendar, only: dt, dt_dyn, ndtd, diagfreq, write_restart, istep
-      use ice_calendar, only: idate, myear, mmonth, mday, msec, timesecs
-      use ice_calendar, only: calendar_sec2hms, write_history, nstreams, histfreq
+      use ice_calendar, only: idate, msec
+      use ice_calendar, only: nstreams
       use ice_diagnostics, only: init_mass_diags, runtime_diags, debug_model, debug_ice
       use ice_diagnostics_bgc, only: hbrine_diags, bgc_diags
       use ice_domain, only: halo_info, nblocks
@@ -136,7 +135,7 @@
       use ice_timers, only: ice_timer_start, ice_timer_stop, &
           timer_diags, timer_column, timer_thermo, timer_bound, &
           timer_hist, timer_readwrite
-      use ice_communicate, only: MPI_COMM_ICE, my_task, master_task
+      use ice_communicate, only: MPI_COMM_ICE
       use ice_prescribed_mod
 
       integer (kind=int_kind) :: &
@@ -155,8 +154,6 @@
       character(len=*), parameter :: subname = '(ice_step)'
 
       character (len=char_len) :: plabeld
-      integer (kind=int_kind)  :: hh,mm,ss,ns
-      character (len=char_len) :: logmsg
 
       if (debug_model) then
          plabeld = 'beginning time step'
@@ -388,15 +385,6 @@
          endif
 
          call ice_timer_stop(timer_readwrite)  ! reading/writing
-         if (my_task == master_task) then
-            do ns = 1,nstreams
-               if (write_history(ns) .and. histfreq(ns) .eq. 'h') then
-                  call calendar_sec2hms(msec,hh,mm,ss)
-                  write(logmsg,'(6(i4,2x))')myear,mmonth,mday,hh,mm,ss
-                  call ufs_logfhour(trim(logmsg),timesecs/c3600)
-               end if
-            end do
-         end if
       end subroutine ice_step
 
 !=======================================================================

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -577,7 +577,7 @@ contains
        nu_diag_set = .true.
     end if
 
-    call NUOPC_CompAttributeGet(gcomp, name="mom6_write_log_to_output_dir", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    call NUOPC_CompAttributeGet(gcomp, name="cice_write_log_to_output_dir", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
        if (trim(cvalue) .eq. '.true.') log_to_output = .true.

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -58,6 +58,7 @@ module ice_comp_nuopc
   use ice_scam           , only : scol_valid, single_column
 #ifndef CESMCOUPLED
   use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, is_restart_fh_type
+  use shr_is_restart_fh_mod, only : log_restart_fh
 #endif
 #ifdef UFS_TRACING
   use ufs_trace_mod
@@ -1051,6 +1052,8 @@ contains
     !---------------------------------------------------------------------------
     ! Run CICE
     !---------------------------------------------------------------------------
+    use ice_calendar,       only: write_history, histfreq, nstreams
+    use ice_history_shared, only: history_dir
 
     ! Arguments
     type(ESMF_GridComp)  :: gcomp
@@ -1084,6 +1087,7 @@ contains
     logical                    :: isPresent, isSet
 #ifndef CESMCOUPLED
     logical                    :: write_restartfh
+    integer                    :: ns
 #endif
     character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
     character(char_len_long)   :: msgString
@@ -1272,6 +1276,23 @@ contains
     if(profile_memory) call ESMF_VMLogMemInfo("Entering CICE_Run : ")
     call CICE_Run()
     if(profile_memory) call ESMF_VMLogMemInfo("Leaving CICE_Run : ")
+
+    !--------------------------------
+    ! Write output logs
+    !--------------------------------
+#ifndef CESMCOUPLED
+    if (mastertask) then
+       do ns = 1, nstreams
+          if (write_history(ns) .and. histfreq(ns) .eq. 'h') then
+             call ESMF_ClockGetNextTime(clock, nextTime=nextTime, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             call log_restart_fh(nextTime, startTime, 'ice', output_dir=history_dir, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             exit
+          end if
+       end do
+    end if
+#endif
 
     !--------------------------------
     ! Create export state

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -104,6 +104,7 @@ module ice_comp_nuopc
   logical                      :: mastertask
   logical                      :: runtimelog = .false.
   logical                      :: restart_eor = .false. !End of run restart flag
+  logical                      :: log_to_output = .false. ! Write logs to CICE output dir
 #ifndef CESMCOUPLED
   type(is_restart_fh_type)     :: restartfh_info     ! For flexible restarts in UFS
 #endif
@@ -576,6 +577,11 @@ contains
        nu_diag_set = .true.
     end if
 
+    call NUOPC_CompAttributeGet(gcomp, name="mom6_write_log_to_output_dir", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       if (trim(cvalue) .eq. '.true.') log_to_output = .true.
+    endif
     !----------------------------------------------------------------------------
     ! First cice initialization phase - before initializing grid info
     !----------------------------------------------------------------------------
@@ -1086,8 +1092,9 @@ contains
     character(char_len_long)   :: restart_filename
     logical                    :: isPresent, isSet
 #ifndef CESMCOUPLED
-    logical                    :: write_restartfh
-    integer                    :: ns
+    character(len=256), allocatable :: logdir
+    logical                         :: write_restartfh
+    integer                         :: ns
 #endif
     character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
     character(char_len_long)   :: msgString
@@ -1281,12 +1288,13 @@ contains
     ! Write output logs
     !--------------------------------
 #ifndef CESMCOUPLED
+    if (log_to_output) logdir=history_dir
     if (mastertask) then
        do ns = 1, nstreams
           if (write_history(ns) .and. histfreq(ns) .eq. 'h') then
              call ESMF_ClockGetNextTime(clock, nextTime=nextTime, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
-             call log_restart_fh(nextTime, startTime, 'ice', output_dir=history_dir, rc=rc)
+             call log_restart_fh(nextTime, startTime, 'ice', output_dir=logdir, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
              exit
           end if


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


This PR will bring remove the CICE logging feature and substitute it with the `log_restart_fh` subroutine. This will bring it in line with the logging method for MOM6 and CMEPS.  An issue was found where the logging timestamps were not correct when the UFS was using IAU. This fixes that issue.

There was also a feature request made by NCO for GFSv17 production to have the logs moved to the output folder for each component. This change was made for production (https://github.com/NOAA-EMC/CICE/commit/77542dcc69403e88c5e35e9f48391f2ed4872f79), however the production changes had no way to allow the user to turn the feature on or off. This PR will add a new option to ufs.configure that will allow the user to specify whether or not they want the logs to be written to the CICE output directory or the run directory.  The default (if the option is not declared) will be to have the logs in the run directory.

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Change logging system to use log_restart_fh and add option to write logs to output directory
- [X] Developer(s): 
    @dpsarmie 
- [ ] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No - the documentation updates will be made at the UFS WM level 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.

This PR will bring remove the CICE logging feature and substitute it with the `log_restart_fh` subroutine. This will bring it in line with the logging method for MOM6 and CMEPS.  An issue was found where the logging timestamps were not correct when the UFS was using IAU. This fixes that issue.

There was also a feature request made by NCO for GFSv17 production to have the logs moved to the output folder for each component. This change was made for production (https://github.com/NOAA-EMC/CICE/commit/77542dcc69403e88c5e35e9f48391f2ed4872f79), however the production changes had no way to allow the user to turn the feature on or off. This PR will add a new option to ufs.configure that will allow the user to specify whether or not they want the logs to be written to the CICE output directory or the run directory.  The default (if the option is not declared) will be to have the logs in the run directory.

